### PR TITLE
Fix compatibility with PHP 5.3 by passing $that alias to closure

### DIFF
--- a/src/MKraemer/ReactPCNTL/PCNTL.php
+++ b/src/MKraemer/ReactPCNTL/PCNTL.php
@@ -27,8 +27,9 @@ class PCNTL extends EventEmitter
      */
     public function on($signo, $listener)
     {
-        pcntl_signal($signo, function ($signo) {
-            $this->emit($signo);
+        $that = $this;
+        pcntl_signal($signo, function ($signo) use ($that) {
+            $that->emit($signo);
         });
         parent::on($signo, $listener);
     }


### PR DESCRIPTION
This small patch fixes compatibility with PHP 5.3 by passing $that alias to closure.
