### PR TITLE
Use * in composer.json so it'll use the best fit (that is dev-master)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
         "psr-0": { "MKraemer": "src/" }
     },
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.0",
         "ext-pcntl": "*",
-        "evenement/evenement": "1.0.*",
-        "react/event-loop": "0.3.*"
+        "evenement/evenement": "*",
+        "react/event-loop": "*"
     }
 }


### PR DESCRIPTION
react-pcntl is compatible with current dev-master (0.4.*)
