### PR TITLE
Target both evenement 3 and 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.4",
         "ext-pcntl": "*",
-        "evenement/evenement": "2.0.*",
+        "evenement/evenement": "^3.0 || ^2.0",
         "react/event-loop": "0.4.*"
     },
     "require-dev": {

--- a/src/MKraemer/ReactPCNTL/PCNTL.php
+++ b/src/MKraemer/ReactPCNTL/PCNTL.php
@@ -67,7 +67,13 @@ class PCNTL extends EventEmitter
      */
     public function on($signo, callable $listener)
     {
-        pcntl_signal($signo, array($this, 'emit'));
+        /*
+         * The associative array given when pcntl_signal calls the handler function
+         * can not be passed on to EventEmitterTrait::emit, as evenement 3
+         * does not support associative arrays. Drop it by using an intermediate
+         * callback function:
+         */
+        pcntl_signal($signo, function () use ($signo) {$this->emit($signo);});
         parent::on($signo, $listener);
     }
 

--- a/test/MKraemer/ReactPCNTL/PCNTLTest.php
+++ b/test/MKraemer/ReactPCNTL/PCNTLTest.php
@@ -57,7 +57,7 @@ class PCNTLTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($listeners));
         $this->assertEquals(1, count(self::$pcntl_signal_args));
         $this->assertArrayHasKey(SIGTERM, self::$pcntl_signal_args);
-        $this->assertSame(array($pcntl, 'emit'), self::$pcntl_signal_args[SIGTERM]);
+        $this->assertInternalType('callable', self::$pcntl_signal_args[SIGTERM]);
     }
 
     public function testInvokeCallsDispatch()
@@ -105,7 +105,7 @@ class PCNTLTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($pcntl->listeners(SIGTERM));
         $this->assertNotEmpty($pcntl->listeners(SIGHUP));
         $this->assertEquals(SIG_DFL, self::$pcntl_signal_args[SIGTERM]);
-        $this->assertSame(array($pcntl, 'emit'), self::$pcntl_signal_args[SIGHUP]);
+        $this->assertInternalType('callable', self::$pcntl_signal_args[SIGHUP]);
     }
 
     public function testRemoveAllListenersOfAllSignals()
@@ -121,5 +121,34 @@ class PCNTLTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(SIG_DFL, self::$pcntl_signal_args[SIGTERM]);
         $this->assertEmpty($pcntl->listeners(SIGHUP));
         $this->assertEquals(SIG_DFL, self::$pcntl_signal_args[SIGHUP]);
+    }
+
+    /**
+     * Evenement 3 breaks when the associative array which
+     * is passed to the listeners registered with pcntl_signal
+     * is passed on to EventEmitterTrait::emit.
+     *
+     * This test ensures these arguments are not passed.
+     */
+    public function testPcntlArgumentsAreNotPassed()
+    {
+        $pcntl = new PCNTL($this->loop);
+
+        $wasCalled = false;
+        $passedArguments = null;
+        $listener = function () use (&$passedArguments, &$wasCalled) {
+            $wasCalled = true;
+            $passedArguments = func_get_args();
+        };
+
+        $pcntl->on(SIGTERM, $listener);
+
+        // pcntl passes this array when calling the registered handlers:
+        $pcntlArguments = array('errno' => 0, 'signo' => 2, 'code' => 128);
+
+        self::$pcntl_signal_args[SIGTERM]($pcntlArguments);
+
+        $this->assertTrue($wasCalled);
+        $this->assertEmpty($passedArguments);
     }
 }

--- a/test/MKraemer/ReactPCNTL/PCNTLTest.php
+++ b/test/MKraemer/ReactPCNTL/PCNTLTest.php
@@ -26,7 +26,6 @@ class PCNTLTest extends \PHPUnit_Framework_TestCase
         $this->loop = $this->getMock('React\EventLoop\LoopInterface');
     }
 
-
     public function testLoopStartStop()
     {
         $timer = $this->getMock('React\EventLoop\Timer\TimerInterface');
@@ -146,7 +145,7 @@ class PCNTLTest extends \PHPUnit_Framework_TestCase
         // pcntl passes this array when calling the registered handlers:
         $pcntlArguments = array('errno' => 0, 'signo' => 2, 'code' => 128);
 
-        self::$pcntl_signal_args[SIGTERM]($pcntlArguments);
+        call_user_func(self::$pcntl_signal_args[SIGTERM], $pcntlArguments);
 
         $this->assertTrue($wasCalled);
         $this->assertEmpty($passedArguments);


### PR DESCRIPTION
Événement `3.0` is nearly fully backwards compatible with `2.0`. It packs some neat performance upgrades without any code changes on nearly all projects using it. Took a quick look at your code base and couldn't find any breaks :shipit: .